### PR TITLE
feat: INDEXの追加

### DIFF
--- a/golang/app.go
+++ b/golang/app.go
@@ -83,6 +83,7 @@ func dbInitialize() {
 		"DELETE FROM comments WHERE id > 100000",
 		"UPDATE users SET del_flg = 0",
 		"UPDATE users SET del_flg = 1 WHERE id % 50 = 0",
+		"ALTER TABLE `comments` ADD INDEX `post_id_index`(`post_id`)",
 	}
 
 	for _, sql := range sqls {

--- a/var/log/mysql/mysql-slow.log
+++ b/var/log/mysql/mysql-slow.log
@@ -2277,3 +2277,5150 @@ SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT
 # Query_time: 2.503585  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
 SET timestamp=1693723674;
 SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+/usr/sbin/mysqld, Version: 8.0.34 (MySQL Community Server - GPL). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time                 Id Command    Argument
+# Time: 2023-09-03T07:33:58.701616Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    38
+# Query_time: 2.014308  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+use isuconp;
+SET timestamp=1693726436;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:33:59.506123Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    29
+# Query_time: 2.693646  Lock_time: 0.000008 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726436;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:33:59.597591Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.096524  Lock_time: 0.002069 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726437;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:00.006705Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.212373  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726437;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:07.398181Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.606658  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726444;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:07.505783Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.304038  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726445;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:07.895090Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.092785  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726445;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:07.900299Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    19
+# Query_time: 2.404006  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726445;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.102862Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.024177  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.279519Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 2.187710  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.285827Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    37
+# Query_time: 2.089772  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.384755Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.188464  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 9744 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.489420Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.296936  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.493490Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    46
+# Query_time: 2.298041  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.681629Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 2.291365  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.683104Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    49
+# Query_time: 2.204308  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:08.795397Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.398307  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 3190 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:09.204585Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.105710  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726447;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:09.403295Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 2.608995  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726446;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:09.705299Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    29
+# Query_time: 2.500950  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726447;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:09.990856Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 2.203070  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726447;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:10.603411Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.008108  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726448;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:11.197929Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    46
+# Query_time: 2.092270  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726449;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:11.402491Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 2.120902  Lock_time: 0.000015 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726449;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:11.702718Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    49
+# Query_time: 2.105596  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726449;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:11.782065Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.182165  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726449;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:12.504541Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    29
+# Query_time: 2.119230  Lock_time: 0.000011 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.002624Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.303711  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.006609Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.928369  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.100202Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 2.113898  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.293011Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.991396  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.304491Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    38
+# Query_time: 2.121462  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726451;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.409900Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 3.009780  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.609658Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.012721  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726450;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.698989Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.195695  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726451;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:13.906965Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    19
+# Query_time: 2.604545  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726451;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:14.100826Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 2.795524  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726451;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:14.102874Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.099582  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726452;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:14.887067Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.404731  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726452;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:14.997813Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.497510  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726452;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:15.409726Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.208092  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726453;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:15.409983Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    29
+# Query_time: 2.205681  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726453;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:15.410130Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    49
+# Query_time: 3.015773  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726452;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:15.985789Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.299383  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726453;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:15.991957Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.591565  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726453;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:16.687577Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 2.584271  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726454;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:16.989443Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.192866  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726454;
+SELECT * FROM `comments` WHERE `post_id` = 1158 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:17.313621Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.808768  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726454;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:17.492226Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.713561  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726454;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:17.495214Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 2.508663  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726454;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:17.778356Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    19
+# Query_time: 2.781884  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726454;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:17.793724Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    37
+# Query_time: 2.384036  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726455;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.306103Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    29
+# Query_time: 2.220791  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.311350Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 3.219810  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726455;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.386247Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.108423  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 9468 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.388360Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.104273  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.396093Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.983445  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726455;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.593720Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.608849  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726455;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.693227Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.597516  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.781782Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    55
+# Query_time: 2.395141  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:18.783291Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    49
+# Query_time: 2.687432  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:19.310439Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.005497  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 5638 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:19.400140Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 3.602045  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726455;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.002050Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 2.324070  Lock_time: 0.000010 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.196467Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.215001  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 9263 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.204450Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 3.825600  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.402112Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.716749  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.406183Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.519628  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.497139Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    56
+# Query_time: 3.911359  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726456;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.501482Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 3.011924  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:20.897960Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.114198  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726458;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:21.509512Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    61
+# Query_time: 3.715705  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:21.702274Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 2.108507  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726459;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:21.802649Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 4.215928  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726457;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.001437Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.398608  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726459;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.091884Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.394604  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726459;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.102421Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 3.613131  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726458;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.093169Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 3.502316  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726458;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.094481Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 2.592116  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726459;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.204155Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 2.113496  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726460;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.397485Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.303394  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726460;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.811759Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.998028  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726459;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:22.887929Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 3.287495  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726459;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:23.106758Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.706629  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726460;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:23.201838Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    49
+# Query_time: 2.304060  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726460;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:23.499199Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.793619  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726460;
+SELECT * FROM `comments` WHERE `post_id` = 7200 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:23.504893Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.615015  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726460;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:24.094279Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.295436  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726461;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:24.104469Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.701745  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726461;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:24.199839Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    56
+# Query_time: 2.503713  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726461;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:25.203727Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.998187  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726462;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:25.600749Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.402599  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:25.604789Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 2.724039  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726462;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:25.786880Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 2.981161  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726462;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.083244Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 2.489749  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.092150Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.587228  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.184916Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 3.090627  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 4997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.388530Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.487859  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.389668Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    18
+# Query_time: 2.489035  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.504578Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.011204  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:26.694730Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 2.603879  Lock_time: 0.000010 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726464;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.096758Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.501929  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726464;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.102420Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 2.404551  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726464;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.188991Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 2.506074  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726464;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.289612Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 3.687764  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726463;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.602070Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.810032  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726464;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.696481Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 3.097696  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726464;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.698199Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 2.205666  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726465;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.702008Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.509216  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726465;
+SELECT * FROM `comments` WHERE `post_id` = 7156 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.784930Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.681266  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726465;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.788213Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.293456  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726465;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:27.788757Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 2.009892  Lock_time: 0.000007 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726465;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:28.585065Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.291320  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:28.689841Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.608187  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:28.692608Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 2.312297  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:28.693445Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.412657  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.196906Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 3.704141  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726465;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.301113Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.513368  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.398649Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    63
+# Query_time: 2.702102  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.506153Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 2.819351  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.503018Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 3.309280  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 6926 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.591901Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 2.104706  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.701096Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    70
+# Query_time: 3.520344  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 7236 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.804414Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 2.011606  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.883999Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.287035  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:29.998306Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 3.600776  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.194095Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 3.404166  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726466;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.503041Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 2.301319  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.509663Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 2.731688  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.607223Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.822283  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.694228Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.495731  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.510499Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    18
+# Query_time: 3.117556  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.697518Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.207864  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.699849Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    73
+# Query_time: 2.114561  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.802881Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.612946  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.805122Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.217557  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 6297 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.810426Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 2.323684  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.811259Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 2.717522  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:30.898633Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 2.003893  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9443 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:31.094590Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.307114  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726467;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:31.094839Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.201092  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:31.094860Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.400137  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:31.892842Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.694660  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 4287 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:31.901224Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 3.220935  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.009407Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 2.414387  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.099030Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.200138  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.103808Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.711560  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.213345Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 2.015925  Lock_time: 0.000095 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.296597Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 2.390932  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.301324Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.909983  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.501149Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.499945  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.698511Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.200477  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.799871Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    69
+# Query_time: 3.498553  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726469;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.880225Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 2.075524  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.895808Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.294009  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:32.901985Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.593726  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 6748 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.100548Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 4.504413  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726468;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.196320Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 2.599513  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.311460Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 3.127259  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.397474Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.797162  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.399906Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 2.420084  Lock_time: 0.000010 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.507861Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 2.810119  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:33.509218Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.101488  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:34.006996Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 3.311246  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:34.085869Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 2.385941  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:34.398392Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 3.090423  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:34.598154Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    70
+# Query_time: 4.001129  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 7094 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:34.605594Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 3.621992  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726470;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:34.684933Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 2.792925  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.094099Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 3.807137  Lock_time: 0.000172 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.189739Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 3.493549  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 6129 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.984513Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 3.483037  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726472;
+SELECT * FROM `comments` WHERE `post_id` = 2946 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.984677Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 4.285945  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.984952Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    69
+# Query_time: 2.188700  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.987757Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.675013  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.988775Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 4.386261  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 8969 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.989602Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.586379  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.992750Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.490770  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.993601Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    73
+# Query_time: 4.094697  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:35.997773Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 2.101728  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.089623Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 3.888704  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726472;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.183041Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 4.685731  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726471;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.095787Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.293054  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.385345Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 2.090620  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.598092Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 3.995142  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726472;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.793012Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.297221  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.898101Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.891054  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.891909Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.393974  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.892019Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.795685  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.890058Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 2.392315  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.997794Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 4.190070  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726472;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.089752Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 2.193776  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.997036Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 2.993379  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.090242Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 3.408562  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.095923Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.002175  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:36.996799Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    63
+# Query_time: 3.295055  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726473;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.381358Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 3.188413  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.503473Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 3.496399  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.504060Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 2.898457  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.506011Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.206831  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726474;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.693972Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 2.094926  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 5808 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:37.979946Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.780940  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 6277 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:38.502657Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.693923  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 5635 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:38.598033Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.003655  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:38.898543Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.991750  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:38.812649Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 3.308925  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.001206Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    75
+# Query_time: 2.114271  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.005415Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.314667  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.184829Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.401847  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726475;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.396747Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 2.603115  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.505153Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    77
+# Query_time: 2.519765  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.701658Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 2.709907  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.793522Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.392436  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:39.896544Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.496229  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.000023Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 2.604720  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.100555Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    74
+# Query_time: 2.921480  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.206533Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.325546  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.283499Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 3.302371  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.297417Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 3.109663  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 5034 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.505519Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    73
+# Query_time: 3.324749  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.579936Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.795672  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.303093Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    85
+# Query_time: 3.603355  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.402472Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 3.622221  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.496151Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.904252  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.496934Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 2.608605  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.588818Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.698705  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.300769Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 3.609444  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726476;
+SELECT * FROM `comments` WHERE `post_id` = 2769 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.695959Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 3.391052  Lock_time: 0.000004 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.705177Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    18
+# Query_time: 3.524677  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.906814Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 3.303316  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 8230 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.907598Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    80
+# Query_time: 3.720802  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.111400Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 3.118760  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.003042Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 3.118816  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.006586Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 3.928562  Lock_time: 0.000004 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.007665Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 3.229720  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.801999Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.913186  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.102889Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 3.211423  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.103156Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    86
+# Query_time: 2.503983  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:40.999322Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 3.105712  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.296077Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 3.895637  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.196891Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 3.413907  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.206894Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 3.121156  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.401336Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    63
+# Query_time: 3.318591  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.486070Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 3.786730  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.708955Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 3.312188  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.714915Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 2.814181  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:41.890338Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.190756  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.100846Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 2.996495  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726479;
+SELECT * FROM `comments` WHERE `post_id` = 4986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.009028Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 4.230139  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726477;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.292614Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 3.104362  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726479;
+SELECT * FROM `comments` WHERE `post_id` = 3134 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.298980Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.598237  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726479;
+SELECT * FROM `comments` WHERE `post_id` = 4777 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.497898Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 3.900986  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.690933Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 3.208125  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726479;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.704250Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.806360  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726479;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.797229Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 4.214260  Lock_time: 0.000014 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726478;
+SELECT * FROM `comments` WHERE `post_id` = 10014 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:42.998769Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 2.706423  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726480;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.102442Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.203371  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726480;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.304801Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 2.010899  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.595575Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 3.098290  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726480;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.891133Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.303450  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.897343Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.185610  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.906699Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.613912  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:43.983288Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.395531  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.001964Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 2.603832  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.003187Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 2.011398  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.008116Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.712115  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726480;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.108325Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 4.101590  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726480;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.294049Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    85
+# Query_time: 3.092886  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.298764Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.708934  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.093429Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 4.194688  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726479;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.199848Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    75
+# Query_time: 2.095117  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.303351Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    86
+# Query_time: 2.322279  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.395757Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.387025  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 1090 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.500535Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 3.393648  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.783368Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 2.091219  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 4976 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:44.899139Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.996265  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.006753Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    80
+# Query_time: 3.213260  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.202435Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.911009  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.208897Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.307948  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.311818Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 3.129057  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.395434Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    74
+# Query_time: 4.292536  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.405373Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 4.212114  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.700697Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 2.096970  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.898492Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 3.892443  Lock_time: 0.002940 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.905669Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 3.618395  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.980961Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 3.800443  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 6520 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.995294Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 2.597058  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.184378Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    73
+# Query_time: 4.676477  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.188994Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 3.891009  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.084393Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 4.492099  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.085688Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 2.792236  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 2619 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:45.995467Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 4.288214  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 4086 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.281631Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 4.486887  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726481;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.285240Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.987504  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 3440 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.481601Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    63
+# Query_time: 4.191811  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.487901Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 4.385870  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.602285Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    18
+# Query_time: 4.502125  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.602353Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 2.607045  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.604231Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.411504  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.796844Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    77
+# Query_time: 3.898080  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.799156Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 2.104476  Lock_time: 0.000014 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.879628Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.276893  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.705003Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 3.004464  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.989358Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.205560  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.995536Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 3.396807  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:46.996549Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    82
+# Query_time: 3.914455  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 7801 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.088768Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 4.296854  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.090382Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 3.487647  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.094073Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.201580  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.184543Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 2.180804  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.292424Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 4.389500  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726482;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.383143Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.400707  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.395491Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 3.393293  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.480691Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.283132  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 1039 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.593245Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    85
+# Query_time: 2.802455  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.602755Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 3.604019  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726483;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.788267Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 3.393525  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.792435Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.594693  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.795938Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    86
+# Query_time: 2.902817  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.985040Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.679608  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.996595Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.192867  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:47.887560Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 3.093774  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726484;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:48.089266Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 2.885770  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:48.402445Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 3.106106  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 819 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:48.900226Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    80
+# Query_time: 2.199386  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:48.901758Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.523634  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:48.906060Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 3.008120  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726485;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.094791Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    74
+# Query_time: 2.898692  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.101150Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.816544  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.378450Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 2.682707  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 6235 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.385860Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.604474  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.496949Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 3.115190  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.598951Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 2.711487  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.692135Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.906979  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.695034Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 3.094486  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.899145Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    73
+# Query_time: 2.818903  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.809377Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 3.218610  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.901162Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.910468  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:49.997815Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 2.904325  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.193561Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 2.999599  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.194716Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 2.912543  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.403366Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 3.113837  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.408279Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 3.410764  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726486;
+SELECT * FROM `comments` WHERE `post_id` = 3148 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.496214Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.399551  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.485255Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 3.305303  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 2472 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.599103Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 3.313621  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 2551 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.600352Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    40
+# Query_time: 2.817565  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.606132Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.912629  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.706066Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 2.625208  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.795968Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    63
+# Query_time: 3.616208  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.800729Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.718396  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.889928Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.805780  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 904 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.897336Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 3.111069  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:50.905685Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 2.617612  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.004171Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 3.407627  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.095636Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 3.114825  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.095776Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 3.706047  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.106486Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    18
+# Query_time: 3.501341  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.203654Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    85
+# Query_time: 2.807914  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.284479Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.478557  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.299816Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 3.019155  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.389617Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    82
+# Query_time: 3.498889  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 7325 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.392250Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 3.402522  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.393398Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 3.201898  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.596531Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 3.412790  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.597996Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 3.411102  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.694626Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    75
+# Query_time: 3.612173  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.698898Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    77
+# Query_time: 3.714171  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726487;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.802359Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 3.719450  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.805506Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 2.714460  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726489;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:51.903028Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    86
+# Query_time: 3.099223  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.003826Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.200801  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726489;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.101999Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 3.504514  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.296203Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.002923  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.304678Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 3.219635  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726489;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.508185Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.119715  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726489;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.702899Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 3.802471  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726488;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:52.705140Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.806041  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726489;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.106547Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    25
+# Query_time: 2.816394  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.197576Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 2.800396  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 5870 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.203463Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    80
+# Query_time: 3.406189  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726489;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.596849Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    74
+# Query_time: 3.299896  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.597854Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 3.402065  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.701107Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.907578  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.901731Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 3.004055  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.905364Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    60
+# Query_time: 2.210325  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.996208Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 2.602630  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.109115Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 3.212485  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.000751Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 3.121186  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:53.998640Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    73
+# Query_time: 3.101120  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.300615Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.901670  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.301774Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 2.908925  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.397273Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 3.303127  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.406130Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.307780  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.504551Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 3.711491  Lock_time: 0.000010 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726490;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.690796Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    82
+# Query_time: 2.184427  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 6330 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.693942Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 3.096033  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.793302Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 3.097937  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.882553Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    85
+# Query_time: 2.582534  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.890797Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 3.093430  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 483 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.800215Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 3.497133  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.892339Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.289097  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.895137Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 3.394905  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 1747 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:54.892273Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    43
+# Query_time: 3.295431  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726491;
+SELECT * FROM `comments` WHERE `post_id` = 642 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:55.294961Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 3.097582  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:55.796303Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 3.293271  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:55.983151Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 3.781676  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:55.986813Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 3.583816  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:55.990069Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    75
+# Query_time: 3.092046  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.094516Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    11
+# Query_time: 3.193965  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.097391Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 3.494367  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.189669Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.891184  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726493;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.284621Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 3.389430  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.392278Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    86
+# Query_time: 3.490769  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.479555Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 2.177387  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 4596 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.385564Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 3.182089  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726493;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.587586Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.805462  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726493;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.704109Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.602570  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.793541Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    77
+# Query_time: 3.895518  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.794484Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 3.811401  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.799176Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    36
+# Query_time: 2.797151  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.894203Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 3.293951  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726493;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.894529Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 3.200660  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726493;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.995820Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    80
+# Query_time: 2.200967  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:57.085411Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 4.485390  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726492;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:56.998966Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.405623  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:57.095718Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.111246  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:57.299418Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 2.211161  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:57.507223Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 2.126927  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:57.590343Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.398410  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:57.980923Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 3.384884  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:58.090615Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    67
+# Query_time: 3.400458  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:58.411641Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 3.231518  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:58.689674Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 4.089113  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726494;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.179443Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 2.188342  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726496;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.396663Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    77
+# Query_time: 2.194632  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726497;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.493890Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    87
+# Query_time: 3.495082  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.604071Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 4.520038  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.505110Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 4.221069  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.906231Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    85
+# Query_time: 4.425660  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:34:59.896862Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 4.600829  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:00.005880Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 4.221387  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:00.198962Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 4.216207  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726495;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:00.394352Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 4.011072  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726496;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:00.402601Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    82
+# Query_time: 4.319835  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726496;
+SELECT * FROM `comments` WHERE `post_id` = 1884 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:00.593237Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 4.005067  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726496;
+SELECT * FROM `comments` WHERE `post_id` = 2051 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:00.898339Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    72
+# Query_time: 3.907745  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726496;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.202110Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 2.605423  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.202855Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.707530  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.399918Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 2.504706  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.499634Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 3.903366  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726497;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.507080Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.006048  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726499;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.801726Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 2.998692  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:01.907278Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 4.608254  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726497;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.080876Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 4.497799  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726497;
+SELECT * FROM `comments` WHERE `post_id` = 3691 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.106394Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 4.024158  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.203744Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 4.408853  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726497;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.207614Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    74
+# Query_time: 3.115439  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726499;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.402159Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 4.311297  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.404645Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.723670  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726499;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.495054Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 2.293614  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.588181Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 3.409459  Lock_time: 0.000053 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726499;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.799222Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.301123  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.893833Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 4.201548  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726498;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.991888Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    59
+# Query_time: 2.891163  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.997403Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 2.492043  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:02.995930Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.794624  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.197261Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 2.296221  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.199348Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    41
+# Query_time: 2.298321  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.204400Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    80
+# Query_time: 3.000246  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.100379Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    87
+# Query_time: 2.805193  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.300481Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 3.200450  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.404991Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    71
+# Query_time: 2.103951  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726501;
+SELECT * FROM `comments` WHERE `post_id` = 133 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.405420Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 2.298380  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726501;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.803979Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 3.604121  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726500;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:03.905909Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    82
+# Query_time: 2.216284  Lock_time: 0.000013 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726501;
+SELECT * FROM `comments` WHERE `post_id` = 575 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.201361Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    52
+# Query_time: 2.498699  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726501;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.405184Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    47
+# Query_time: 2.109938  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.503769Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.411169  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.603590Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    22
+# Query_time: 2.308412  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.609319Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.017171  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.803085Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 2.710542  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:04.899282Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.991926  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726501;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.307461Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 2.908434  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.392080Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 2.694048  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.392576Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    42
+# Query_time: 3.180562  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.407766Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.221633  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.392879Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    12
+# Query_time: 2.800525  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.502768Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 2.700789  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726502;
+SELECT * FROM `comments` WHERE `post_id` = 3502 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.603482Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    57
+# Query_time: 2.118504  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.610371Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.314925  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.699296Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    74
+# Query_time: 2.490266  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.803274Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.495970  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.899201Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    79
+# Query_time: 2.604822  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.984125Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.578537  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.984176Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.077829  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.985131Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    53
+# Query_time: 2.499086  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:05.986936Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    87
+# Query_time: 2.181401  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:06.088032Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    27
+# Query_time: 2.000329  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726504;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:06.281473Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    66
+# Query_time: 2.979948  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:06.493720Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 2.796687  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:07.194810Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    62
+# Query_time: 3.200771  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:07.200767Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    50
+# Query_time: 2.012572  Lock_time: 0.000011 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726505;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:07.202692Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    68
+# Query_time: 3.222093  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726503;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:07.595600Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    78
+# Query_time: 2.084788  Lock_time: 0.000027 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726505;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:07.701028Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    13
+# Query_time: 3.593003  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726504;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:07.902578Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    58
+# Query_time: 2.202522  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726505;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.186681Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    44
+# Query_time: 3.186999  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726504;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.492491Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    23
+# Query_time: 2.690795  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726505;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.690555Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    51
+# Query_time: 2.501239  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.804198Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    65
+# Query_time: 2.716890  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.899303Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    83
+# Query_time: 3.099573  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726505;
+SELECT * FROM `comments` WHERE `post_id` = 2939 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.902232Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    84
+# Query_time: 2.915552  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726505;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.999709Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    39
+# Query_time: 2.203482  Lock_time: 0.000011 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.102382Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    81
+# Query_time: 2.810879  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:08.995472Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    24
+# Query_time: 2.502601  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.005378Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    31
+# Query_time: 2.009486  Lock_time: 0.000036 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.295175Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    64
+# Query_time: 2.108107  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726507;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.304350Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    76
+# Query_time: 2.907311  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726506;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.495108Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    77
+# Query_time: 2.491531  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726507;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.497243Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    10
+# Query_time: 2.301852  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726507;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.598032Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
+# Query_time: 2.297162  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726507;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:09.698986Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    54
+# Query_time: 2.113243  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726507;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+/usr/sbin/mysqld, Version: 8.0.34 (MySQL Community Server - GPL). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time                 Id Command    Argument
+# Time: 2023-09-03T07:35:49.501149Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    22
+# Query_time: 2.010984  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+use isuconp;
+SET timestamp=1693726547;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:49.899423Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.017894  Lock_time: 0.000004 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726547;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:52.799168Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.111208  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726550;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:59.701655Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.007707  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726557;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:59.899875Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    49
+# Query_time: 2.104360  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726557;
+SELECT * FROM `comments` WHERE `post_id` = 3114 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:35:59.908657Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.119834  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726557;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.107867Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 2.118779  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726557;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.004154Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    50
+# Query_time: 2.123324  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726557;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.281459Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    38
+# Query_time: 2.201915  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.293111Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.113404  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.797781Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.098828  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.799925Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.506736  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.997562Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    34
+# Query_time: 2.301846  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:00.997920Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.192256  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:01.503835Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.096874  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726559;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:01.802013Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:     8
+# Query_time: 2.289796  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726559;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:02.006456Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:     9
+# Query_time: 3.310439  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726558;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:02.180622Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    40
+# Query_time: 2.171653  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726560;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:02.296349Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 2.492851  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726559;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:02.398035Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.189857  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726560;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:02.882506Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.872604  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726560;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:02.908916Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.401946  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726560;
+SELECT * FROM `comments` WHERE `post_id` = 8888 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:03.103429Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    50
+# Query_time: 2.506239  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726560;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:04.387657Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.884709  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726561;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:04.401140Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    54
+# Query_time: 2.221902  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726562;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:04.800741Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.212345  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726562;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:04.905117Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.100097  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726562;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:05.693463Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.193587  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726563;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:07.280494Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.582542  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726564;
+SELECT * FROM `comments` WHERE `post_id` = 4262 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:09.105723Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.214074  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726566;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:09.203800Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.005828  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:09.401255Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.004470  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:09.403626Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.403739  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726566;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:09.406475Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.208190  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:09.799043Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    64
+# Query_time: 2.217939  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 8972 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.000636Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.200931  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.196014Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    61
+# Query_time: 2.315887  Lock_time: 0.000004 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.199478Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.115378  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726568;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.200735Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    37
+# Query_time: 2.107849  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726568;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.707109Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.827060  Lock_time: 0.000006 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.799244Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 3.000021  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:10.808363Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 3.125479  Lock_time: 0.001561 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726567;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:11.185100Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    39
+# Query_time: 2.990845  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726568;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:11.306620Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 2.005662  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726569;
+SELECT * FROM `comments` WHERE `post_id` = 8488 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:11.307723Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.811767  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726568;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:11.401823Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 2.504436  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726568;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:11.504729Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.722102  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726568;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:11.802620Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.105876  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726569;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.083708Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.175264  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726569;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.281543Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.274166  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.506369Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.505269  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.703235Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    67
+# Query_time: 2.405273  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.704111Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.403782  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.905476Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:     8
+# Query_time: 2.204434  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:12.985119Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.290955  Lock_time: 0.000012 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:13.099229Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    57
+# Query_time: 2.200594  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:13.395427Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.811429  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726570;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:13.690289Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.483366  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726571;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:13.792638Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 2.286072  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726571;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:14.002316Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 2.198364  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726571;
+SELECT * FROM `comments` WHERE `post_id` = 8331 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:14.301378Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 2.402577  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726571;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:14.493551Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    64
+# Query_time: 2.199006  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726572;
+SELECT * FROM `comments` WHERE `post_id` = 7405 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:14.494195Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.489081  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726572;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.098014Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.618354  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726572;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.599249Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.208769  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.607591Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.208641  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.696027Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.506919  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.805469Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 2.204444  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.806282Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    60
+# Query_time: 2.902444  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726572;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.879251Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.499871  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:15.987573Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.394358  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:16.084809Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    67
+# Query_time: 2.486810  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:16.183666Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.680555  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:16.196025Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.692977  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726573;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:16.810487Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.316080  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726574;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:17.303862Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 3.106497  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726574;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:17.382536Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.481588  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726574;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:17.394038Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.803059  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726574;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:17.582997Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    64
+# Query_time: 2.289028  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726575;
+SELECT * FROM `comments` WHERE `post_id` = 6824 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:18.592314Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 2.290163  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726576;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:18.801156Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.498987  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726576;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:18.997344Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    67
+# Query_time: 2.093670  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726576;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:19.195687Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 3.003017  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726576;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:19.204622Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.008346  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:19.292190Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 2.608854  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726576;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:19.299791Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.008554  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:19.906668Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.801553  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.012171Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.720655  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.097229Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 2.802667  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.099271Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.903377  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.103299Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    69
+# Query_time: 2.409976  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.305069Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:     9
+# Query_time: 2.117017  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.609679Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.225533  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.699989Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 2.518183  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.700519Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 3.005697  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.703350Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.809392  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.796806Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.703849  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.900089Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.905168  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9860 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.903952Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.519899  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:20.999335Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 3.302611  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:21.189339Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.091346  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726579;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:21.195311Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    60
+# Query_time: 2.701354  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:21.005277Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 3.221435  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726577;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:21.693564Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 3.502836  Lock_time: 0.000000 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:21.899121Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.599251  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726579;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:21.805062Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 2.609799  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726579;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:22.293492Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 4.110534  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:22.298240Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.215771  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726580;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:22.803194Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 4.617240  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726578;
+SELECT * FROM `comments` WHERE `post_id` = 4901 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.105935Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.502287  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726580;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.291503Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    69
+# Query_time: 2.388949  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726580;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.504329Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.105458  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.686872Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 3.993180  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726579;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.693813Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.387994  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.696663Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 2.291107  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.704955Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.598974  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.803693Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 3.006871  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726580;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.804946Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.400240  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:23.694458Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 3.494302  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726580;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.008293Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.908741  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.203616Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.699518  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.205231Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 3.011538  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.299344Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.996824  Lock_time: 0.000026 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.302591Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 2.710914  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.209446Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 2.301754  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.283808Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 3.678245  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726580;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.401763Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 2.303844  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.503044Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:     9
+# Query_time: 3.203621  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726581;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.507149Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    39
+# Query_time: 2.212428  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.594605Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.297731  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:24.597981Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.499928  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.007068Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.504949  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.306929Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 2.013255  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726583;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.393140Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.190415  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726583;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.702877Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.808563  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.799219Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    67
+# Query_time: 2.996625  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.803743Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.905371  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726582;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.804472Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    60
+# Query_time: 2.306905  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726583;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:25.990569Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.989765  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726583;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.002390Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 2.305246  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726583;
+SELECT * FROM `comments` WHERE `post_id` = 4833 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.687308Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.283622  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.700000Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.498274  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.780475Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 2.773549  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.782024Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 2.382457  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.789224Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    80
+# Query_time: 2.709463  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.792136Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.692427  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 6718 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.793096Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.391070  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:26.880882Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    81
+# Query_time: 2.796268  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:27.202678Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.205924  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:27.589948Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 2.687395  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:27.592091Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 3.096245  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:27.688135Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.787588  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:27.884003Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.992245  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:27.891452Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 3.189584  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726584;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.086877Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.877251  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.101346Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 2.997335  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.184240Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    39
+# Query_time: 2.576905  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.200819Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 2.804546  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.489969Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 2.685404  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.592794Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.895443  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 4964 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.682695Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.787921  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.693903Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 3.396338  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.788123Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 3.492601  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:28.794647Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.800391  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726585;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.092493Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 3.000928  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.198370Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.907721  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.204696Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.724390  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.305752Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.809120  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.306907Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    60
+# Query_time: 3.008134  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.590088Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 3.399381  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.796013Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 3.308946  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:29.896803Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 3.199996  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 4258 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.208225Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.224493  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726587;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.208882Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.106439  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.299130Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 3.401783  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 4547 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.399096Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 3.810865  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.598342Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 2.017970  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.599050Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    69
+# Query_time: 3.897932  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726586;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.700916Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 2.513583  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.705248Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 2.213065  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9892 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:30.904875Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.309327  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.008914Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 3.620316  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726587;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.012889Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 2.319173  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.013906Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.216333  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.098599Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.211417  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.101725Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.413163  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.101841Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 3.113467  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726587;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.307602Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 2.103038  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726589;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.398441Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 2.915888  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:31.704235Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 3.111154  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 8596 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.099341Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 4.108414  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726587;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.103572Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    80
+# Query_time: 4.110136  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726587;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.194100Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 2.187357  Lock_time: 0.000005 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.197595Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 4.015178  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 4768 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.199125Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 3.513398  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.203209Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 3.523369  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.205134Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 4.210126  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726587;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.296326Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    81
+# Query_time: 4.214752  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.508059Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 4.320189  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.595594Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 3.603808  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.587677Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.186378  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.501346Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    60
+# Query_time: 2.310399  Lock_time: 0.000013 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.506986Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 3.927135  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.693111Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 4.208262  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.804273Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 3.121603  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726589;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.807980Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.508131  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.812567Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 2.218396  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.895718Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 3.592136  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726589;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:32.901101Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.300907  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:33.305909Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 4.517577  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726588;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:33.404631Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.105882  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:33.492080Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 3.189295  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 4951 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:33.597856Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 4.397206  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726589;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:33.881028Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 4.788225  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726589;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.007776Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.406180  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.182440Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.671878  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.198851Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.897286  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.203426Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.398868  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.296827Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 2.102718  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726592;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.299848Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 2.792432  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.304371Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.417791  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.395581Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 3.297065  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 10015 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.689350Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 4.586775  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:34.997447Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 2.893575  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726592;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:35.800667Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 5.903473  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726589;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:35.887445Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    80
+# Query_time: 2.989398  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726592;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:35.982934Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.686549  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 2409 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:35.988077Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.591507  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:35.991471Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.591902  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.095245Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 4.695643  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.087342Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 2.606970  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.181768Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 2.975203  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.182675Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.693832  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.085069Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.076445  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726594;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.290569Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 2.593436  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.291994Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 6.090305  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726590;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.294172Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 5.205503  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.399404Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    14
+# Query_time: 4.600798  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 2334 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.695596Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 3.102725  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.810739Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 3.025771  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:36.812159Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 3.227605  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.101974Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 5.209335  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726591;
+SELECT * FROM `comments` WHERE `post_id` = 2924 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.112268Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 4.306846  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726592;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.297023Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 5.296780  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726592;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.597370Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    69
+# Query_time: 5.488303  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726592;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.598905Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.504882  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.694750Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.594823  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.700791Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 3.012233  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726594;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:37.904845Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 4.507258  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.000285Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 3.899716  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726594;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.179888Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 3.077554  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.194067Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 2.790505  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 8129 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.200484Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.800929  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.390562Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 4.284151  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726594;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.298676Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.312967  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 4089 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.299409Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 3.192674  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.486211Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 4.605118  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726593;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.292291Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 2.689726  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.684704Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 3.384131  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.687854Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 4.493077  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726594;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.498601Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 3.901112  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726594;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.794418Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.705149  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:38.897287Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 3.614370  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.103095Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 3.507520  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726595;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.400779Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 2.794372  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 3474 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.508648Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 3.211062  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.599647Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 2.414008  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.605727Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.506798  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.404010Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.500182  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 2254 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.699245Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.596915  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.703663Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    68
+# Query_time: 2.594877  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.700864Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 3.618216  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.708149Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.012030  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:39.902167Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    81
+# Query_time: 3.206528  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.100972Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    80
+# Query_time: 3.402741  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726596;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.187513Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.486272  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.197426Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 2.109636  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.301461Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.901899  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.308643Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    13
+# Query_time: 2.408081  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.403590Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.806527  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.306848Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.603047  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.305177Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.021452  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.582067Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.885819  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.592931Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 3.012065  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.598557Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 2.595442  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.702483Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 2.519354  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.891459Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.511640  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:40.901396Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.512679  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:41.102100Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 3.216523  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726597;
+SELECT * FROM `comments` WHERE `post_id` = 374 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:41.102180Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.092474  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:41.300006Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 2.707272  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:41.506637Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 2.306678  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 8100 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:41.605180Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 2.410752  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:41.607446Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 2.815265  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.005018Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.300620  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.006941Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 3.412018  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726598;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.395586Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.799008  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.489997Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.792178  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.501252Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 3.109578  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.598450Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 2.899931  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.599338Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.903671  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.698773Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    43
+# Query_time: 2.692325  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.699844Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.904745  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 4040 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.808769Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 3.021699  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.781042Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.185378  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.706523Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.009129  Lock_time: 0.000014 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.900702Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 3.506069  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.901619Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 3.203786  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.096612Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.195889  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.997513Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 2.116850  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:42.906352Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.398473  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.099606Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 3.496046  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.101080Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    30
+# Query_time: 3.313185  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 646 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.295393Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 3.506633  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726599;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.504339Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 3.111826  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 2626 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.789597Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    81
+# Query_time: 2.892034  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.797743Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 3.496679  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.798084Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 3.014270  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 1563 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.898982Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.199155  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:43.796596Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 3.498068  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.094409Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 3.493985  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.203021Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    62
+# Query_time: 3.897456  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.501092Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 3.903902  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726600;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.611525Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 2.214174  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726602;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.697169Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 3.395042  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.707314Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 3.206561  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.888995Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.397077  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726602;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:44.803285Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 3.610219  Lock_time: 0.000011 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.117228Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 3.721646  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.293681Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.301052  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726602;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.393823Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 3.698994  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.409186Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 2.004277  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.207332Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 2.215646  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726602;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.206312Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 3.503229  Lock_time: 0.000028 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:45.705161Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 3.706342  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726601;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.084311Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.679800  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.089817Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.683733  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.093948Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.193551  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.189579Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 2.508451  Lock_time: 0.000012 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.293271Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 3.495328  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726602;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.401489Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.400712  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726604;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.581283Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.684286  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.688559Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 2.793711  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:46.881675Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 2.183576  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726604;
+SELECT * FROM `comments` WHERE `post_id` = 2001 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.000462Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.205883  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726604;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.106852Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 3.416425  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.306507Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.008948  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.401782Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 3.708217  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726603;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.703997Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.108346  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.709169Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 2.308725  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.597355Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 3.297793  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726604;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.887411Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    71
+# Query_time: 3.881699  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726604;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:47.889565Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.291108  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:48.186118Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 2.300127  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:48.199390Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 3.796802  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726604;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:48.200590Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    15
+# Query_time: 2.310683  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.206069Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 2.518410  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726606;
+SELECT * FROM `comments` WHERE `post_id` = 6913 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.308125Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.008595  Lock_time: 0.000008 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.405335Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.821451  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726606;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.399550Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 2.098069  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.600605Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 2.814028  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726606;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.308841Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 4.109621  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.508727Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 2.207354  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.408715Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    53
+# Query_time: 2.514695  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726606;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.709003Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 4.511564  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 1127 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:49.799916Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 3.703308  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726606;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.002626Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 2.014583  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 1723 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.083266Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 2.383685  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.196824Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.997877  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.207468Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.522480  Lock_time: 0.000014 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.301783Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 4.507291  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726605;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.402306Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.105723  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.896473Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 2.496465  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:50.899039Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 2.404278  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.093981Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 3.701979  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.203638Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.214752  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.296040Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.997461  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.395024Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 3.512328  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.403389Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.515648  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.403516Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 3.906824  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726607;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.495776Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 3.007946  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 1453 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.603879Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.813020  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.705138Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 3.017525  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:51.894667Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 3.206089  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726608;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:52.081363Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.480544  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726609;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:52.096839Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 2.198499  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726609;
+SELECT * FROM `comments` WHERE `post_id` = 5797 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:52.395840Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 2.211374  Lock_time: 0.000011 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:52.500909Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.102711  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:52.605329Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.006354  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:52.809427Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.307146  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.002010Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.097254  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.095543Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 2.494775  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.095959Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 2.399132  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.104530Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 2.507208  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.193414Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 2.799733  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.200898Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 2.808911  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.203374Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.801133  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.400825Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.800872  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.694691Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 2.989108  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.705582Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 3.203278  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 1093 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.696883Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    81
+# Query_time: 2.193037  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726611;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.696356Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.814502  Lock_time: 0.000012 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726610;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:53.996547Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.898396  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726611;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.201320Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.301199  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726611;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.299889Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.898628  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726611;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.396094Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.002967  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.590554Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 3.295705  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726611;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.597570Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.596865  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.606058Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.308287  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.985278Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.483247  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:54.990424Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.487241  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.294211Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 3.196770  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.400065Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.007872  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.404484Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 3.218814  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726612;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.697414Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.502548  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.705529Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    87
+# Query_time: 2.402494  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.709087Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 2.014206  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:55.982339Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 2.375513  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.190851Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 2.493778  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.504211Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.198391  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726614;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.516987Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.910154  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.806394Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 2.807979  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.807906Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.922898  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.899921Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 3.007089  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.902667Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.922421  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726613;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:56.908240Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.317307  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726614;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:57.209163Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.717280  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726614;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:57.400926Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 3.196927  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726614;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:57.585386Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 2.290607  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726615;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:57.506096Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.611281  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726614;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:57.501660Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.604467  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726614;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:57.596958Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 2.490245  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726615;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.103641Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.505805  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726615;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.487051Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 2.597323  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726615;
+SELECT * FROM `comments` WHERE `post_id` = 5091 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.487150Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.491339  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726615;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.588486Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    84
+# Query_time: 2.793054  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726615;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.594768Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.493947  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.693061Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.511510  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.797324Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    70
+# Query_time: 2.615834  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.803534Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 2.705442  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.895425Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    65
+# Query_time: 2.713506  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:58.904411Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 2.608573  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.100201Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    89
+# Query_time: 2.291940  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.102313Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.497468  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.200425Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    29
+# Query_time: 2.000603  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726617;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.206951Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    47
+# Query_time: 2.500137  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.400129Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 2.593623  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726616;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.704475Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.119040  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726617;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:36:59.793889Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.101826  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726617;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.206154Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.516361  Lock_time: 0.000000 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726617;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.507643Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 2.308816  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726618;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.602371Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    86
+# Query_time: 2.115523  Lock_time: 0.000006 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726618;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.605121Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.302826  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726618;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.609023Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.020318  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726618;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.612842Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.826903  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726617;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:00.801736Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.507318  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726618;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:01.096872Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    95
+# Query_time: 2.700940  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726618;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:01.100473Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 2.099652  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:01.504664Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    91
+# Query_time: 2.297772  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 5045 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:01.706438Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.604096  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:01.903062Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.698646  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.201760Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.302161  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.202434Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    75
+# Query_time: 2.801592  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.299401Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    63
+# Query_time: 2.401064  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.405376Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 2.505037  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.512132Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.915703  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.598862Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    73
+# Query_time: 2.799870  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726619;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.697212Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.387390  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726620;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.794897Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 2.495816  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726620;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:02.805575Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.604567  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726620;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:03.009257Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    90
+# Query_time: 2.007436  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:03.602289Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    92
+# Query_time: 2.315601  Lock_time: 0.000009 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:03.995965Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    76
+# Query_time: 2.285464  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:04.002112Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.792284  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:04.003065Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    25
+# Query_time: 2.489222  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:03.998310Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    52
+# Query_time: 2.200176  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:04.192112Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.393283  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:04.192222Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    83
+# Query_time: 2.593500  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:04.296970Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    48
+# Query_time: 2.602102  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726621;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:04.610106Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.315256  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726622;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:05.007793Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    51
+# Query_time: 2.410963  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726622;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:05.805606Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.413150  Lock_time: 0.000010 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:05.888606Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    79
+# Query_time: 2.380777  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:05.982010Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 3.180663  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726622;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:05.992221Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    55
+# Query_time: 2.597020  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:06.182140Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    85
+# Query_time: 2.483552  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:06.194254Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    72
+# Query_time: 2.393426  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:06.293974Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    74
+# Query_time: 2.712893  Lock_time: 0.000010 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:06.397087Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    94
+# Query_time: 2.596262  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726623;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:06.696376Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.394893  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726624;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:07.302072Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 2.106336  Lock_time: 0.000007 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726625;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:07.510009Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    82
+# Query_time: 2.111548  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726625;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:07.787805Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    66
+# Query_time: 2.490747  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726625;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:07.797888Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    93
+# Query_time: 2.292578  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726625;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:08.191215Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    23
+# Query_time: 2.096274  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726626;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:08.892654Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    36
+# Query_time: 2.198978  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726626;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:10.281949Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    58
+# Query_time: 2.294041  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726627;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:10.383174Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    88
+# Query_time: 2.385353  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726627;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:10.506451Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    56
+# Query_time: 2.000613  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726628;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:10.506791Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    78
+# Query_time: 2.321262  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726628;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:10.808570Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    35
+# Query_time: 2.022501  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726628;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:11.397381Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    46
+# Query_time: 2.492550  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726628;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2023-09-03T07:37:12.700456Z
+# User@Host: root[root] @ webapp-app-1.webapp_default [172.19.0.4]  Id:    81
+# Query_time: 2.399633  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1693726630;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+/usr/sbin/mysqld, Version: 8.0.34 (MySQL Community Server - GPL). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time                 Id Command    Argument
+/usr/sbin/mysqld, Version: 8.0.34 (MySQL Community Server - GPL). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time                 Id Command    Argument
+/usr/sbin/mysqld, Version: 8.0.34 (MySQL Community Server - GPL). started with:
+Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
+Time                 Id Command    Argument


### PR DESCRIPTION
# Overview

INDEX制約を付けることによるクエリの高速化

# Issue number

# How to check the revision

# Points for Review



# Remarks

2秒以上かかっているクエリを確認すると以下のようになっていた。

```SQL
/usr/sbin/mysqld, Version: 8.0.34 (MySQL Community Server - GPL). started with:
Tcp port: 3306  Unix socket: /var/lib/mysql/mysql.sock
Time                 Id Command    Argument
# Time: 2023-09-03T06:46:40.021513Z
# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    35
# Query_time: 2.104932  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
use isuconp;
SET timestamp=1693723597;
SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
# Time: 2023-09-03T06:46:41.224452Z
# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    20
# Query_time: 2.201496  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
SET timestamp=1693723599;
SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
# Time: 2023-09-03T06:46:43.126719Z
# User@Host: root[root] @ webapp-app-1.webapp_default [172.18.0.4]  Id:    34
# Query_time: 2.022988  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
SET timestamp=1693723601;
SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
```

変わっているのは`post_id`の部分だけ

おそらく`post_id`は一意なのでカーディナリティが高いことからINDEXを張ることで遅くなることはならないと判断して制約をつけました。

# Score
0点から21534点に